### PR TITLE
fix(compat): convert invalid `into` into a cast

### DIFF
--- a/src/lexer/tokenizer.rs
+++ b/src/lexer/tokenizer.rs
@@ -36,7 +36,7 @@ pub fn tokenizer(contents: &str) -> Vec<Token> {
                     }
                 }
 
-                '`' => tokens.push(Token::Literal(Value::MLStr(c.into()))),
+                '`' => tokens.push(Token::Literal(Value::MLStr(c as u64))),
                 '"' => tokens.push(Token::Literal(Value::Char((c as u8).to_string()))),
                 '\'' => tokens.push(Token::Literal(Value::Char((c as u8).to_string()))),
                 '0'..='9' => {


### PR DESCRIPTION
It wasn't working on Windows PowerShell with the Rustup v1.50.0 toolkit.  This fixed it.  Here was the stack trace:

```sh
error[E0277]: the trait bound `u64: From<char>` is not satisfied
  --> src\lexer\tokenizer.rs:39:64
   |
39 |                 '`' => tokens.push(Token::Literal(Value::MLStr(c.into()))),
   |                                                                ^^^^^^^^ the trait `From<char>` is not 
implemented for `u64`
   |
   = help: the following implementations were found:
             <u64 as From<NonZeroU64>>
             <u64 as From<bool>>
             <u64 as From<u32>>
             <u64 as From<u8>>
   = note: required because of the requirements on the impl of `Into<u64>` for `char`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
```

Perhaps you were using nightly or the latest stable version has this implemented.