### PR TITLE
style: fix lint warnings

### DIFF
--- a/src/commands/unkown.rs
+++ b/src/commands/unkown.rs
@@ -59,7 +59,7 @@ Flags:
             "--release",
             "-r",
         ];
-        let flags = app.filter_flag(&acceptedflags);
+        let _flags = app.filter_flag(&acceptedflags);
 
         let args = app.args.clone();
         let filename: &str = args[0].as_str();

--- a/src/lexer/operations.rs
+++ b/src/lexer/operations.rs
@@ -33,9 +33,9 @@ pub enum Types {
 }
 #[derive(Debug)]
 pub struct Function {
-    pub isasync: bool,
+    pub is_async: bool,
     pub name: String,
-    pub returnType: Types,
+    pub return_type: Types,
     pub arguments: Vec<Variable>,
     pub statements: Vec<Statement>,
 }

--- a/src/lexer/parser.rs
+++ b/src/lexer/parser.rs
@@ -154,13 +154,11 @@ impl Parser {
 
     fn parse_function(&mut self) -> Result<Function, String> {
         self.match_keyword(&Keyword::Func)?;
-        let mut isasync = false;
-        let mut returnType: Types;
+        let mut is_async = false;
+        let return_type: Types;
         if let Some(Token::Keyword(Keyword::Async)) = self.peek() {
             self.next();
-            isasync = true;
-        } else {
-            isasync = false
+            is_async = true;
         }
         // panic!("{:#?}", self.peek());
         let name = self.match_identifier()?;
@@ -175,9 +173,9 @@ impl Parser {
         self.match_token(Token::CloseParen)?;
         if self.peek().unwrap() == Token::Colon {
             self.match_token(Token::Colon)?;
-            returnType = self.parse_return();
+            return_type = self.parse_return();
         } else {
-            returnType = Types::Void;
+            return_type = Types::Void;
         }
         self.match_token(Token::OpenBrace)?;
 
@@ -191,10 +189,10 @@ impl Parser {
         self.match_token(Token::CloseBrace)?;
 
         Ok(Function {
-            isasync,
+            is_async,
             name,
             arguments,
-            returnType,
+            return_type,
             statements,
         })
     }
@@ -292,7 +290,7 @@ impl Parser {
                 let exp = self.parse_expression();
                 Ok(Statement::Declare(Variable { name, size }, Some(exp)))
             }
-            other => Err("Variables should be assigned".to_string()),
+            _ => Err("Variables should be assigned".to_string()),
         }
     }
 


### PR DESCRIPTION
Notes:
* I just changed the `flags` variable name to `_flags` to suppress the warning because I figured that someone was probably going to still be using it a some point.
* I renamed the `isasync` `Function` property to `is_async` and `returnType` to `return_type` because a) that's a heck of a lot more readable and b) we should keep the snake case variable/struct property style consistent across the code in Rust.
* Some of the variables were mutable which wasn't actually required so this got rid of some warnings.